### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/quickstrap/quickstrap.png?label=ready&title=Ready)](https://waffle.io/quickstrap/quickstrap)
 [![Code Climate](https://codeclimate.com/github/quickstrap/quickstrap/badges/gpa.svg)](https://codeclimate.com/github/quickstrap/quickstrap)
 [![Test Coverage](https://codeclimate.com/github/quickstrap/quickstrap/badges/coverage.svg)](https://codeclimate.com/github/quickstrap/quickstrap/coverage)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/quickstrap/quickstrap

This was requested by a real person (user jeremygiberson) on waffle.io, we're not trying to spam you.
